### PR TITLE
conventions: add format-for-like, and format for/async, for/list/concurrent

### DIFF
--- a/tests/general.rkt
+++ b/tests/general.rkt
@@ -99,3 +99,22 @@ g
 
 (struct a (a b) ; hello
       )
+
+(for/list/concurrent ([i (in-range 10)])
+  i)
+
+(for/list/concurrent #:group (make-thread-group)
+                     ([i (in-range 10)])
+  i)
+
+(for/vector ([i (in-range 10)]) i)
+
+(for/vector #:length 20
+            ([i (in-range 10)]) i)
+
+(for/vector #:length 20 #:fill 5
+            ([i (in-range 10)]) i)
+
+(for/vector #:length 20 #:fill (let ()
+                                 5)
+            ([i (in-range 10)]) i)

--- a/tests/general.rkt.out
+++ b/tests/general.rkt.out
@@ -100,3 +100,25 @@ c
 
 (struct a (a b) ; hello
   )
+
+(for/list/concurrent ([i (in-range 10)])
+  i)
+
+(for/list/concurrent #:group (make-thread-group)
+                     ([i (in-range 10)])
+  i)
+
+(for/vector ([i (in-range 10)])
+  i)
+
+(for/vector #:length 20
+            ([i (in-range 10)])
+  i)
+
+(for/vector #:length 20 #:fill 5
+            ([i (in-range 10)])
+  i)
+
+(for/vector #:length 20 #:fill (let () 5)
+            ([i (in-range 10)])
+  i)


### PR DESCRIPTION
`format-for-like` handles keyword arguments before the for-clause groups. 

I kind of winged this without fully grokking everything, so there may be better ways to achieve the same thing. Also, this is biased towards the way emacs indents these things, which is different from the way drracket does (it doesn't vertically align the keywords and the clause groups).