### PR TITLE
Avoid writing file in-place when no changes

### DIFF
--- a/raco.rkt
+++ b/raco.rkt
@@ -117,9 +117,11 @@
   [_
    (for ([filename (in-list filenames)])
      ;; use file->lines to handle CRLF on Windows
-     (define out (do-format (string-join (file->lines filename) "\n")))
+     (define original (string-join (file->lines filename) "\n"))
+     (define out (do-format original))
      (case (current-in-place?)
        [(#f) (displayln out)]
-       [(#t) (with-output-to-file filename
-               #:exists 'must-truncate
-               (λ () (displayln out)))]))])
+       [(#t) (or (equal? original out)
+                 (with-output-to-file filename
+                   #:exists 'must-truncate
+                   (λ () (displayln out))))]))])

--- a/raco.rkt
+++ b/raco.rkt
@@ -121,7 +121,7 @@
      (define out (do-format original))
      (case (current-in-place?)
        [(#f) (displayln out)]
-       [(#t) (or (equal? original out)
-                 (with-output-to-file filename
-                   #:exists 'must-truncate
-                   (λ () (displayln out))))]))])
+       [(#t) (unless (equal? original out)
+               (with-output-to-file filename
+                 #:exists 'must-truncate
+                 (λ () (displayln out))))]))])


### PR DESCRIPTION
One use case for this is for other tools that watch for file changes (e.g. `inotifywait`). Another is for tools that look at file timestamps (e.g. `make`). Both of these kinds of tools usually only want to do work when the file really changes.

I've only just started learning Racket, so if I've done anything weird by conventions please let me know!

I didn't spot any automated tests for the `raco.rkt` file to add on to, and I'm not sure I'm confident enough yet to add a new test suite. But I did test this manually using an inotify-based tool and it seems to fix the issue I was seeing.