### PR TITLE
Add a contract to main API

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -4,16 +4,28 @@
 
 (define-logger fmt)
 
-(provide program-format
-         empty-formatter-map
-         compose-formatter-map
-         pretty-print*
-         pretty-format*
-         formatter-map/c
-         (all-from-out "core.rkt")
-         (all-from-out "params.rkt")
-         (all-from-out "common.rkt")
-         (all-from-out "conventions.rkt"))
+(require racket/contract/base)
+
+(provide
+ (contract-out
+  [program-format
+   (->* (string?)
+        (#:formatter-map formatter-map/c
+         #:source any/c
+         #:width (or/c exact-nonnegative-integer? +inf.0)
+         #:limit (or/c exact-nonnegative-integer? +inf.0)
+         #:max-blank-lines (or/c exact-nonnegative-integer? +inf.0)
+         #:indent exact-nonnegative-integer?)
+        (and/c string? immutable?))])
+ empty-formatter-map
+ compose-formatter-map
+ pretty-print*
+ pretty-format*
+ formatter-map/c
+ (all-from-out "core.rkt")
+ (all-from-out "params.rkt")
+ (all-from-out "common.rkt")
+ (all-from-out "conventions.rkt"))
 
 (require racket/string
          racket/contract

--- a/main.rkt
+++ b/main.rkt
@@ -93,9 +93,10 @@
    #f
    #f)
 
-  (string-join (for/list ([line (in-list all-lines)])
-                 (string-trim line #:left? #f))
-               "\n"))
+  (string->immutable-string
+   (string-join (for/list ([line (in-list all-lines)])
+                  (string-trim line #:left? #f))
+                "\n")))
 
 (define ((compose-formatter-map . fs) x)
   (for/or ([f (in-list fs)])


### PR DESCRIPTION
I'd like to call `program-format` from Resyntax, and I'd like a contract to tell me if I messed it up. Is adding contracts to this reasonable? The tradeoff is that it will result in slower startup time, though I haven't measured the difference.

I'm not sure of the exact contract that should be used since not all of the available keyword args are documented.