### PR TITLE
Move memoization to utility module

### DIFF
--- a/private/memoize.rkt
+++ b/private/memoize.rkt
@@ -1,0 +1,12 @@
+#lang racket/base
+
+(provide define/memoize)
+
+(require syntax/parse/define)
+
+(define (memoize f #:backend [backend make-weak-hasheq])
+  (define table (backend))
+  (λ (x) (hash-ref! table x (λ () (f x)))))
+
+(define-syntax-parse-rule (define/memoize (function:id arg:id) body:expr ...+)
+  (define function (memoize (λ (arg) body ...))))


### PR DESCRIPTION
Also, add a `define/memoize` macro to make the memoized code a bit more readable.